### PR TITLE
fix(auth): return 400 for invalid current password

### DIFF
--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -54,7 +54,7 @@ export class AuthService {
     const valid = await verifyPassword(user.passwordHash, currentPassword)
 
     if (!valid) {
-      throw new AppError('目前密碼錯誤', 401)
+      throw new AppError('INVALID_CURRENT_PASSWORD', 400)
     }
 
     const isSamePassword = await verifyPassword(user.passwordHash, newPassword)

--- a/backend/tests/auth.service.spec.ts
+++ b/backend/tests/auth.service.spec.ts
@@ -64,6 +64,25 @@ describe('AuthService', () => {
     )
   })
 
+  it('throws 400 when current password is invalid', async () => {
+    findUnique.mockResolvedValue({
+      id: 'user-1',
+      username: 'admin',
+      role: 'admin',
+      status: 'active',
+      passwordHash: 'old-hash',
+      mustChangePwd: true
+    })
+    verifyPassword.mockResolvedValue(false)
+
+    await expect(service.changePassword('user-1', 'WrongPass123!', 'NewTempPass123!')).rejects.toMatchObject({
+      message: 'INVALID_CURRENT_PASSWORD',
+      statusCode: 400
+    })
+    expect(hashPassword).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+
   it('throws 400 when new password equals current password', async () => {
     findUnique.mockResolvedValue({
       id: 'user-1',

--- a/frontend/src/pages/change-password-page.test.tsx
+++ b/frontend/src/pages/change-password-page.test.tsx
@@ -98,6 +98,34 @@ describe('ChangePasswordPage', () => {
     expect(navigateMock).toHaveBeenCalledWith('/')
   })
 
+  it('shows specific error when current password is invalid', async () => {
+    vi.mocked(axios.isAxiosError).mockReturnValue(true)
+    postMock.mockRejectedValue({
+      response: {
+        status: 400,
+        data: {
+          message: 'INVALID_CURRENT_PASSWORD'
+        }
+      }
+    })
+
+    render(
+      <MemoryRouter>
+        <ChangePasswordPage />
+      </MemoryRouter>
+    )
+
+    fireEvent.change(screen.getByLabelText('目前密碼'), { target: { value: 'WrongPass123!' } })
+    fireEvent.change(screen.getByLabelText('新密碼'), { target: { value: 'NewPass123!@#' } })
+    fireEvent.change(screen.getByLabelText('確認新密碼'), { target: { value: 'NewPass123!@#' } })
+    fireEvent.click(screen.getByRole('button', { name: '更新密碼' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('目前密碼不正確')).toBeInTheDocument()
+    })
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
   it('shows specific error when new password matches current password', async () => {
     vi.mocked(axios.isAxiosError).mockReturnValue(true)
     postMock.mockRejectedValue({

--- a/frontend/src/pages/change-password-page.tsx
+++ b/frontend/src/pages/change-password-page.tsx
@@ -53,9 +53,16 @@ export function ChangePasswordPage() {
       reset()
       navigate('/')
     } catch (error) {
-      if (axios.isAxiosError(error) && error.response?.data?.message === 'NEW_PASSWORD_SAME_AS_OLD') {
-        setErrorMessage('新密碼不能與目前密碼相同')
-        return
+      if (axios.isAxiosError(error)) {
+        const message = error.response?.data?.message
+        if (message === 'NEW_PASSWORD_SAME_AS_OLD') {
+          setErrorMessage('新密碼不能與目前密碼相同')
+          return
+        }
+        if (message === 'INVALID_CURRENT_PASSWORD') {
+          setErrorMessage('目前密碼不正確')
+          return
+        }
       }
       setErrorMessage('修改密碼失敗，請確認目前密碼是否正確')
     }


### PR DESCRIPTION
## Summary
- Return 400 `INVALID_CURRENT_PASSWORD` when an authenticated change-password request has the wrong current password.
- Show a specific Traditional Chinese error on the change-password page without touching the 401 interceptor.
- Add backend and frontend regression tests for the invalid-current-password path.

## Test plan
- [x] `cd backend && npm test -- auth.service`
- [x] `cd frontend && npm test -- change-password-page`
- [x] `npm test`
- [x] `npm run build`
- [x] `cd frontend && npm run lint`
- [ ] `npm run lint` (blocked: root has no ESLint flat config; ESLint v9 exits before workspace scripts)
- [ ] `cd backend && npm run lint` (blocked after build output exists: lint picks up generated `dist`; source files pass in log)

Closes #9