### PR TITLE
fix(auth): persist lastLoginAt on successful login

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -31,15 +31,13 @@ export async function login(req: Request, res: Response, next: NextFunction): Pr
       throw new AppError('登入已被鎖定，請 15 分鐘後再試', 429)
     }
 
-    const loginResult = await authService.login(req.body.username, req.body.password, ipAddress)
+    const loginResult = await authService.login(
+      req.body.username,
+      req.body.password,
+      ipAddress,
+      req.headers['user-agent'] ?? null
+    )
     resetFailedLogins(ipAddress)
-
-    res.locals.username = req.body.username
-    res.locals.entityId = req.body.username
-    res.locals.newValue = { event: 'login_success' }
-
-    res.locals.action = 'login'
-    res.locals.entity = 'auth'
 
     res.json(loginResult)
   } catch (error) {

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -11,7 +11,12 @@ type LoginResult = {
 }
 
 export class AuthService {
-  async login(username: string, password: string, ipAddress: string | null): Promise<LoginResult> {
+  async login(
+    username: string,
+    password: string,
+    ipAddress: string | null,
+    userAgent: string | null = null
+  ): Promise<LoginResult> {
     const user = await prisma.user.findUnique({ where: { username } })
 
     if (!user || user.status !== 'active') {
@@ -24,14 +29,33 @@ export class AuthService {
       throw new AppError('帳號或密碼錯誤', 401)
     }
 
-    await prisma.user.update({
-      where: { id: user.id },
-      data: {
-        lastLoginAt: new Date(),
-        lastLoginIp: ipAddress,
-        failedLogins: 0,
-        lockedUntil: null
-      }
+    const lastLoginAt = new Date()
+
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: user.id },
+        data: {
+          lastLoginAt,
+          lastLoginIp: ipAddress,
+          failedLogins: 0,
+          lockedUntil: null
+        }
+      })
+
+      await tx.auditLog.create({
+        data: {
+          userId: user.id,
+          username: user.username,
+          action: 'login',
+          entity: 'auth',
+          entityId: user.username,
+          oldValue: null,
+          newValue: JSON.stringify({ event: 'login_success', lastLoginAt: lastLoginAt.toISOString() }),
+          ipAddress,
+          userAgent,
+          timestamp: lastLoginAt
+        }
+      })
     })
 
     const options: SignOptions = {

--- a/backend/tests/auth.service.spec.ts
+++ b/backend/tests/auth.service.spec.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { findUnique, update, hashPassword, verifyPassword } = vi.hoisted(() => ({
+const { findUnique, update, auditLogCreate, transaction, hashPassword, verifyPassword } = vi.hoisted(() => ({
   findUnique: vi.fn(),
   update: vi.fn(),
+  auditLogCreate: vi.fn(),
+  transaction: vi.fn(),
   hashPassword: vi.fn(),
   verifyPassword: vi.fn()
 }))
@@ -19,7 +21,11 @@ vi.mock('../src/lib/prisma.js', () => ({
     user: {
       findUnique,
       update
-    }
+    },
+    auditLog: {
+      create: auditLogCreate
+    },
+    $transaction: transaction
   }
 }))
 
@@ -36,8 +42,11 @@ describe('AuthService', () => {
   beforeEach(() => {
     findUnique.mockReset()
     update.mockReset()
+    auditLogCreate.mockReset()
+    transaction.mockReset()
     hashPassword.mockReset()
     verifyPassword.mockReset()
+    transaction.mockImplementation(async (callback) => callback({ user: { update }, auditLog: { create: auditLogCreate } }))
   })
 
   it('returns token and mustChangePwd on login', async () => {
@@ -51,17 +60,83 @@ describe('AuthService', () => {
     })
     verifyPassword.mockResolvedValue(true)
     update.mockResolvedValue({})
+    auditLogCreate.mockResolvedValue({})
 
-    const result = await service.login('admin', 'TempPass123!', '127.0.0.1')
+    const before = Date.now()
+    const result = await service.login('admin', 'TempPass123!', '127.0.0.1', 'vitest-agent')
+    const after = Date.now()
 
     expect(result.mustChangePwd).toBe(true)
     expect(result.token).toEqual(expect.any(String))
+    expect(transaction).toHaveBeenCalledOnce()
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 'user-1' },
-        data: expect.objectContaining({ failedLogins: 0 })
+        data: expect.objectContaining({
+          lastLoginAt: expect.any(Date),
+          lastLoginIp: '127.0.0.1',
+          failedLogins: 0,
+          lockedUntil: null
+        })
       })
     )
+
+    const lastLoginAt = update.mock.calls[0][0].data.lastLoginAt as Date
+    expect(lastLoginAt.getTime()).toBeGreaterThanOrEqual(before)
+    expect(lastLoginAt.getTime()).toBeLessThanOrEqual(after)
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'user-1',
+        username: 'admin',
+        action: 'login',
+        entity: 'auth',
+        entityId: 'admin',
+        oldValue: null,
+        newValue: JSON.stringify({ event: 'login_success', lastLoginAt: lastLoginAt.toISOString() }),
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest-agent',
+        timestamp: lastLoginAt
+      })
+    })
+  })
+
+  it('does not update lastLoginAt when login password is invalid', async () => {
+    findUnique.mockResolvedValue({
+      id: 'user-1',
+      username: 'admin',
+      role: 'admin',
+      status: 'active',
+      passwordHash: 'hash',
+      mustChangePwd: true
+    })
+    verifyPassword.mockResolvedValue(false)
+
+    await expect(service.login('admin', 'WrongPass123!', '127.0.0.1')).rejects.toMatchObject({
+      message: '帳號或密碼錯誤',
+      statusCode: 401
+    })
+    expect(transaction).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+    expect(auditLogCreate).not.toHaveBeenCalled()
+  })
+
+  it('keeps login user update and audit write in one transaction', async () => {
+    findUnique.mockResolvedValue({
+      id: 'user-1',
+      username: 'admin',
+      role: 'admin',
+      status: 'active',
+      passwordHash: 'hash',
+      mustChangePwd: true
+    })
+    verifyPassword.mockResolvedValue(true)
+    update.mockResolvedValue({})
+    auditLogCreate.mockRejectedValue(new Error('audit failed'))
+
+    await expect(service.login('admin', 'TempPass123!', '127.0.0.1')).rejects.toThrow('audit failed')
+    expect(transaction).toHaveBeenCalledOnce()
+    expect(update).toHaveBeenCalledOnce()
+    expect(auditLogCreate).toHaveBeenCalledOnce()
   })
 
   it('throws 400 when current password is invalid', async () => {


### PR DESCRIPTION
## Summary
- Move successful login audit writing from the response middleware locals path into `AuthService.login`.
- Update `User.lastLoginAt`, login IP/reset fields, and `login_success` audit log inside one Prisma transaction.
- Keep failed login behavior unchanged: no `lastLoginAt` update, while `login_fail` audit remains on the controller catch path.

## Audit path trade-off
This PR intentionally makes login success use the service-level audit path so `lastLoginAt` and `login_success` are atomic. Other controller audit events still use the existing middleware locals path from Phase 1, so audit writing is temporarily split across two paths.

Follow-up: Phase 2 前考慮統一 audit 寫入路徑（建獨立 issue）.

## Test plan
- [x] `npm test --workspace backend`

Closes #10