### PR TITLE
chore: clean up lint configuration

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -2,6 +2,9 @@ import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**']
+  },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run test -w backend && npm run test -w frontend",
     "dev": "npm run dev -w backend & npm run dev -w frontend",
     "build": "npm run build -w backend && npm run build -w frontend",
-    "lint": "npm run lint -w backend && npm run lint -w frontend"
+    "lint": "npm run lint --workspaces --if-present"
   },
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary
- Change the root lint script to delegate through npm workspaces with `--if-present`.
- Add backend ESLint ignores for generated and dependency output directories.

## Test plan
- [x] `rtk proxy npm run build --workspace backend`
- [x] `rtk proxy npm run lint --workspace backend`
- [x] `rtk proxy npm run lint`
- [x] `rtk proxy npm test`

Closes #12
Closes #13