### PR TITLE
feat: add subcontractor and site CRUD

### DIFF
--- a/backend/src/controllers/master-data.schemas.ts
+++ b/backend/src/controllers/master-data.schemas.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod'
+
+const optionalText = z.string().trim().optional()
+const nonEmptyText = z.string().trim().min(1, '必填')
+
+export const listQuerySchema = z.object({
+  search: z.string().trim().optional(),
+  status: z.string().trim().optional(),
+  page: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().positive().max(200).optional()
+})
+
+export const createSubcontractorSchema = z.object({
+  code: nonEmptyText,
+  nameZh: nonEmptyText,
+  nameEn: optionalText,
+  brNo: optionalText,
+  contactName: optionalText,
+  contactPhone: optionalText,
+  contactEmail: z.email('電郵格式不正確').optional().or(z.literal('')),
+  status: z.enum(['active', 'inactive']).optional(),
+  remarks: optionalText
+})
+
+export const updateSubcontractorSchema = createSubcontractorSchema
+  .omit({ code: true })
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, { message: '請至少提供一個更新欄位' })
+
+export const createSiteSchema = z.object({
+  code: nonEmptyText,
+  nameZh: nonEmptyText,
+  address: optionalText,
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date().optional(),
+  pmName: optionalText,
+  status: z.enum(['active', 'closed']).optional(),
+  remarks: optionalText
+})
+
+export const updateSiteSchema = createSiteSchema
+  .omit({ code: true })
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, { message: '請至少提供一個更新欄位' })

--- a/backend/src/controllers/site.controller.ts
+++ b/backend/src/controllers/site.controller.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, Response } from 'express'
+import { listQuerySchema } from './master-data.schemas.js'
+import { SiteService } from '../services/master-data.service.js'
+
+const siteService = new SiteService()
+
+function requestMeta(req: Request) {
+  return {
+    ipAddress: req.ip ?? null,
+    userAgent: req.headers['user-agent'] ?? null
+  }
+}
+
+function routeId(req: Request): string {
+  return String(req.params.id)
+}
+
+export async function listSites(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const filters = listQuerySchema.parse(req.query)
+    const result = await siteService.list({
+      ...filters,
+      status: filters.status === 'active' || filters.status === 'closed' ? filters.status : undefined
+    })
+    res.json({ success: true, data: result.items, meta: result.meta })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function getSite(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const site = await siteService.get(routeId(req))
+    res.json({ success: true, data: site })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function createSite(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const site = await siteService.create(req.body, req.user!, requestMeta(req))
+    res.status(201).json({ success: true, data: site })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function updateSite(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const site = await siteService.update(routeId(req), req.body, req.user!, requestMeta(req))
+    res.json({ success: true, data: site })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function deleteSite(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await siteService.delete(routeId(req), req.user!, requestMeta(req))
+    res.json({ success: true })
+  } catch (error) {
+    next(error)
+  }
+}

--- a/backend/src/controllers/subcontractor.controller.ts
+++ b/backend/src/controllers/subcontractor.controller.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, Response } from 'express'
+import { listQuerySchema } from './master-data.schemas.js'
+import { SubcontractorService } from '../services/master-data.service.js'
+
+const subcontractorService = new SubcontractorService()
+
+function requestMeta(req: Request) {
+  return {
+    ipAddress: req.ip ?? null,
+    userAgent: req.headers['user-agent'] ?? null
+  }
+}
+
+function routeId(req: Request): string {
+  return String(req.params.id)
+}
+
+export async function listSubcontractors(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const filters = listQuerySchema.parse(req.query)
+    const result = await subcontractorService.list({
+      ...filters,
+      status: filters.status === 'active' || filters.status === 'inactive' ? filters.status : undefined
+    })
+    res.json({ success: true, data: result.items, meta: result.meta })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function getSubcontractor(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const subcontractor = await subcontractorService.get(routeId(req))
+    res.json({ success: true, data: subcontractor })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function createSubcontractor(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const subcontractor = await subcontractorService.create(req.body, req.user!, requestMeta(req))
+    res.status(201).json({ success: true, data: subcontractor })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function updateSubcontractor(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const subcontractor = await subcontractorService.update(routeId(req), req.body, req.user!, requestMeta(req))
+    res.json({ success: true, data: subcontractor })
+  } catch (error) {
+    next(error)
+  }
+}
+
+export async function deleteSubcontractor(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    await subcontractorService.delete(routeId(req), req.user!, requestMeta(req))
+    res.json({ success: true })
+  } catch (error) {
+    next(error)
+  }
+}

--- a/backend/src/middlewares/error.middleware.ts
+++ b/backend/src/middlewares/error.middleware.ts
@@ -3,6 +3,18 @@ import { AppError } from '../utils/app-error.js'
 
 export function errorMiddleware(error: unknown, _req: Request, res: Response, _next: NextFunction): void {
   if (error instanceof AppError) {
+    if (error.metadata?.code) {
+      res.status(error.statusCode).json({
+        success: false,
+        error: {
+          code: error.metadata.code,
+          message: error.message,
+          details: error.metadata.details
+        }
+      })
+      return
+    }
+
     res.status(error.statusCode).json({ message: error.message })
     return
   }

--- a/backend/src/middlewares/validation.middleware.ts
+++ b/backend/src/middlewares/validation.middleware.ts
@@ -2,14 +2,25 @@ import type { NextFunction, Request, Response } from 'express'
 import type { ZodSchema } from 'zod'
 import { AppError } from '../utils/app-error.js'
 
-export const validateBody = <T>(schema: ZodSchema<T>) => (req: Request, _res: Response, next: NextFunction): void => {
-  const result = schema.safeParse(req.body)
-
-  if (!result.success) {
-    next(new AppError(result.error.issues[0]?.message ?? '驗證錯誤', 400))
-    return
-  }
-
-  req.body = result.data
-  next()
+type ValidateOptions = {
+  format?: 'legacy' | 'v2'
 }
+
+export const validateBody =
+  <T>(schema: ZodSchema<T>, options: ValidateOptions = {}) =>
+  (req: Request, _res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.body)
+
+    if (!result.success) {
+      if (options.format === 'v2') {
+        next(new AppError('驗證錯誤', 400, { code: 'VALIDATION_ERROR', details: result.error.issues }))
+        return
+      }
+
+      next(new AppError(result.error.issues[0]?.message ?? '驗證錯誤', 400))
+      return
+    }
+
+    req.body = result.data
+    next()
+  }

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -2,9 +2,13 @@ import { Router } from 'express'
 import { healthRouter } from './health.routes.js'
 import { authRouter } from './auth.routes.js'
 import { auditRouter } from './audit.routes.js'
+import { subcontractorRouter } from './subcontractor.routes.js'
+import { siteRouter } from './site.routes.js'
 
 export const apiRouter = Router()
 
 apiRouter.use('/', healthRouter)
 apiRouter.use('/auth', authRouter)
 apiRouter.use('/audit', auditRouter)
+apiRouter.use('/subcontractors', subcontractorRouter)
+apiRouter.use('/sites', siteRouter)

--- a/backend/src/routes/site.routes.ts
+++ b/backend/src/routes/site.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express'
+import { createSite, deleteSite, getSite, listSites, updateSite } from '../controllers/site.controller.js'
+import { createSiteSchema, updateSiteSchema } from '../controllers/master-data.schemas.js'
+import { requireAuth } from '../middlewares/auth.middleware.js'
+import { authReadRateLimiter } from '../middlewares/rate-limit.middleware.js'
+import { validateBody } from '../middlewares/validation.middleware.js'
+
+export const siteRouter = Router()
+
+siteRouter.use(requireAuth)
+siteRouter.get('/', authReadRateLimiter, listSites)
+siteRouter.get('/:id', authReadRateLimiter, getSite)
+siteRouter.post('/', validateBody(createSiteSchema, { format: 'v2' }), createSite)
+siteRouter.patch('/:id', validateBody(updateSiteSchema, { format: 'v2' }), updateSite)
+siteRouter.delete('/:id', deleteSite)

--- a/backend/src/routes/subcontractor.routes.ts
+++ b/backend/src/routes/subcontractor.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express'
+import {
+  createSubcontractor,
+  deleteSubcontractor,
+  getSubcontractor,
+  listSubcontractors,
+  updateSubcontractor
+} from '../controllers/subcontractor.controller.js'
+import { createSubcontractorSchema, updateSubcontractorSchema } from '../controllers/master-data.schemas.js'
+import { requireAuth } from '../middlewares/auth.middleware.js'
+import { authReadRateLimiter } from '../middlewares/rate-limit.middleware.js'
+import { validateBody } from '../middlewares/validation.middleware.js'
+
+export const subcontractorRouter = Router()
+
+subcontractorRouter.use(requireAuth)
+subcontractorRouter.get('/', authReadRateLimiter, listSubcontractors)
+subcontractorRouter.get('/:id', authReadRateLimiter, getSubcontractor)
+subcontractorRouter.post('/', validateBody(createSubcontractorSchema, { format: 'v2' }), createSubcontractor)
+subcontractorRouter.patch('/:id', validateBody(updateSubcontractorSchema, { format: 'v2' }), updateSubcontractor)
+subcontractorRouter.delete('/:id', deleteSubcontractor)

--- a/backend/src/services/master-data.service.ts
+++ b/backend/src/services/master-data.service.ts
@@ -1,0 +1,385 @@
+import type { Prisma, Site, Subcontractor } from '@prisma/client'
+import { prisma } from '../lib/prisma.js'
+import { AppError } from '../utils/app-error.js'
+
+export type Actor = {
+  id: string
+  username: string
+  role: string
+}
+
+export type RequestMeta = {
+  ipAddress: string | null
+  userAgent: string | null
+}
+
+export type PaginationMeta = {
+  page: number
+  limit: number
+  total: number
+}
+
+type ListResult<T> = {
+  items: T[]
+  meta: PaginationMeta
+}
+
+export type SubcontractorListFilter = {
+  search?: string
+  status?: 'active' | 'inactive'
+  page?: number
+  limit?: number
+}
+
+export type CreateSubcontractorInput = {
+  code: string
+  nameZh: string
+  nameEn?: string
+  brNo?: string
+  contactName?: string
+  contactPhone?: string
+  contactEmail?: string
+  status?: 'active' | 'inactive'
+  remarks?: string
+}
+
+export type UpdateSubcontractorInput = Omit<Partial<CreateSubcontractorInput>, 'code'>
+
+const subcontractorAuditFields = [
+  'code',
+  'nameZh',
+  'nameEn',
+  'brNo',
+  'contactName',
+  'contactPhone',
+  'contactEmail',
+  'status',
+  'remarks'
+] as const
+
+const normalizeOptionalString = (value: string | undefined) => value ?? null
+
+function subcontractorSnapshot(record: Subcontractor): Record<string, unknown> {
+  return Object.fromEntries(subcontractorAuditFields.map((field) => [field, record[field]]))
+}
+
+function diffSubcontractor(
+  record: Subcontractor,
+  input: UpdateSubcontractorInput
+): { oldValue: Record<string, unknown>; newValue: Record<string, unknown> } {
+  const oldValue: Record<string, unknown> = {}
+  const newValue: Record<string, unknown> = {}
+
+  for (const field of subcontractorAuditFields) {
+    if (field === 'code' || !(field in input)) continue
+    const nextValue = normalizeOptionalString(input[field])
+    if (record[field] !== nextValue) {
+      oldValue[field] = record[field]
+      newValue[field] = nextValue
+    }
+  }
+
+  return { oldValue, newValue }
+}
+
+function normalizePage(page: number | undefined): number {
+  return Math.max(1, page ?? 1)
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  return Math.min(200, Math.max(1, limit ?? 50))
+}
+
+export class SubcontractorService {
+  async list(filters: SubcontractorListFilter = {}): Promise<ListResult<Subcontractor>> {
+    const page = normalizePage(filters.page)
+    const limit = normalizeLimit(filters.limit)
+    const where: Prisma.SubcontractorWhereInput = {
+      status: filters.status ?? { not: 'deleted' }
+    }
+
+    if (filters.search) {
+      where.OR = [
+        { code: { contains: filters.search } },
+        { nameZh: { contains: filters.search } },
+        { nameEn: { contains: filters.search } },
+        { brNo: { contains: filters.search } }
+      ]
+    }
+
+    const [items, total] = await Promise.all([
+      prisma.subcontractor.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit
+      }),
+      prisma.subcontractor.count({ where })
+    ])
+
+    return { items, meta: { page, limit, total } }
+  }
+
+  async get(id: string): Promise<Subcontractor> {
+    const subcontractor = await prisma.subcontractor.findFirst({ where: { id, status: { not: 'deleted' } } })
+
+    if (!subcontractor) {
+      throw new AppError('分判商不存在', 404)
+    }
+
+    return subcontractor
+  }
+
+  async create(input: CreateSubcontractorInput, actor: Actor, meta: RequestMeta): Promise<Subcontractor> {
+    return prisma.$transaction(async (tx) => {
+      const subcontractor = await tx.subcontractor.create({
+        data: {
+          ...input,
+          status: input.status ?? 'active'
+        }
+      })
+
+      await tx.auditLog.create({
+        data: {
+          userId: actor.id,
+          username: actor.username,
+          action: 'create',
+          entity: 'subcontractor',
+          entityId: subcontractor.id,
+          oldValue: null,
+          newValue: JSON.stringify(subcontractorSnapshot(subcontractor)),
+          ipAddress: meta.ipAddress,
+          userAgent: meta.userAgent
+        }
+      })
+
+      return subcontractor
+    })
+  }
+
+  async update(
+    id: string,
+    input: UpdateSubcontractorInput,
+    actor: Actor,
+    meta: RequestMeta
+  ): Promise<Subcontractor> {
+    const current = await this.get(id)
+    const { oldValue, newValue } = diffSubcontractor(current, input)
+
+    return prisma.$transaction(async (tx) => {
+      const subcontractor = await tx.subcontractor.update({
+        where: { id },
+        data: input
+      })
+
+      await tx.auditLog.create({
+        data: {
+          userId: actor.id,
+          username: actor.username,
+          action: 'update',
+          entity: 'subcontractor',
+          entityId: id,
+          oldValue: JSON.stringify(oldValue),
+          newValue: JSON.stringify(newValue),
+          ipAddress: meta.ipAddress,
+          userAgent: meta.userAgent
+        }
+      })
+
+      return subcontractor
+    })
+  }
+
+  async delete(id: string, actor: Actor, meta: RequestMeta): Promise<void> {
+    const current = await this.get(id)
+
+    await prisma.$transaction(async (tx) => {
+      await tx.subcontractor.update({
+        where: { id },
+        data: { status: 'deleted' }
+      })
+
+      await tx.auditLog.create({
+        data: {
+          userId: actor.id,
+          username: actor.username,
+          action: 'delete',
+          entity: 'subcontractor',
+          entityId: id,
+          oldValue: JSON.stringify(subcontractorSnapshot(current)),
+          newValue: JSON.stringify({ status: 'deleted' }),
+          ipAddress: meta.ipAddress,
+          userAgent: meta.userAgent
+        }
+      })
+    })
+  }
+}
+
+export type SiteListFilter = {
+  search?: string
+  status?: 'active' | 'closed'
+  page?: number
+  limit?: number
+}
+
+export type CreateSiteInput = {
+  code: string
+  nameZh: string
+  address?: string
+  startDate: Date
+  endDate?: Date
+  pmName?: string
+  status?: 'active' | 'closed'
+  remarks?: string
+}
+
+export type UpdateSiteInput = Omit<Partial<CreateSiteInput>, 'code'>
+
+const siteAuditFields = ['code', 'nameZh', 'address', 'startDate', 'endDate', 'pmName', 'status', 'remarks'] as const
+
+function serializeDateValue(value: unknown): unknown {
+  return value instanceof Date ? value.toISOString() : value
+}
+
+function siteSnapshot(record: Site): Record<string, unknown> {
+  return Object.fromEntries(siteAuditFields.map((field) => [field, serializeDateValue(record[field])]))
+}
+
+function diffSite(record: Site, input: UpdateSiteInput): { oldValue: Record<string, unknown>; newValue: Record<string, unknown> } {
+  const oldValue: Record<string, unknown> = {}
+  const newValue: Record<string, unknown> = {}
+
+  for (const field of siteAuditFields) {
+    if (field === 'code' || !(field in input)) continue
+    const nextValue = serializeDateValue(input[field]) ?? null
+    const currentValue = serializeDateValue(record[field])
+    if (currentValue !== nextValue) {
+      oldValue[field] = currentValue
+      newValue[field] = nextValue
+    }
+  }
+
+  return { oldValue, newValue }
+}
+
+export class SiteService {
+  async list(filters: SiteListFilter = {}): Promise<ListResult<Site>> {
+    const page = normalizePage(filters.page)
+    const limit = normalizeLimit(filters.limit)
+    const where: Prisma.SiteWhereInput = {
+      status: filters.status ?? { not: 'deleted' }
+    }
+
+    if (filters.search) {
+      where.OR = [
+        { code: { contains: filters.search } },
+        { nameZh: { contains: filters.search } },
+        { address: { contains: filters.search } },
+        { pmName: { contains: filters.search } }
+      ]
+    }
+
+    const [items, total] = await Promise.all([
+      prisma.site.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit
+      }),
+      prisma.site.count({ where })
+    ])
+
+    return { items, meta: { page, limit, total } }
+  }
+
+  async get(id: string): Promise<Site> {
+    const site = await prisma.site.findFirst({ where: { id, status: { not: 'deleted' } } })
+
+    if (!site) {
+      throw new AppError('地盤不存在', 404)
+    }
+
+    return site
+  }
+
+  async create(input: CreateSiteInput, actor: Actor, meta: RequestMeta): Promise<Site> {
+    return prisma.$transaction(async (tx) => {
+      const site = await tx.site.create({
+        data: {
+          ...input,
+          status: input.status ?? 'active'
+        }
+      })
+
+      await tx.auditLog.create({
+        data: {
+          userId: actor.id,
+          username: actor.username,
+          action: 'create',
+          entity: 'site',
+          entityId: site.id,
+          oldValue: null,
+          newValue: JSON.stringify(siteSnapshot(site)),
+          ipAddress: meta.ipAddress,
+          userAgent: meta.userAgent
+        }
+      })
+
+      return site
+    })
+  }
+
+  async update(id: string, input: UpdateSiteInput, actor: Actor, meta: RequestMeta): Promise<Site> {
+    const current = await this.get(id)
+    const { oldValue, newValue } = diffSite(current, input)
+
+    return prisma.$transaction(async (tx) => {
+      const site = await tx.site.update({
+        where: { id },
+        data: input
+      })
+
+      await tx.auditLog.create({
+        data: {
+          userId: actor.id,
+          username: actor.username,
+          action: 'update',
+          entity: 'site',
+          entityId: id,
+          oldValue: JSON.stringify(oldValue),
+          newValue: JSON.stringify(newValue),
+          ipAddress: meta.ipAddress,
+          userAgent: meta.userAgent
+        }
+      })
+
+      return site
+    })
+  }
+
+  async delete(id: string, actor: Actor, meta: RequestMeta): Promise<void> {
+    const current = await this.get(id)
+
+    await prisma.$transaction(async (tx) => {
+      await tx.site.update({
+        where: { id },
+        data: { status: 'deleted' }
+      })
+
+      await tx.auditLog.create({
+        data: {
+          userId: actor.id,
+          username: actor.username,
+          action: 'delete',
+          entity: 'site',
+          entityId: id,
+          oldValue: JSON.stringify(siteSnapshot(current)),
+          newValue: JSON.stringify({ status: 'deleted' }),
+          ipAddress: meta.ipAddress,
+          userAgent: meta.userAgent
+        }
+      })
+    })
+  }
+}

--- a/backend/src/utils/app-error.ts
+++ b/backend/src/utils/app-error.ts
@@ -1,8 +1,15 @@
+export type AppErrorMetadata = {
+  code?: string
+  details?: unknown
+}
+
 export class AppError extends Error {
   statusCode: number
+  metadata?: AppErrorMetadata
 
-  constructor(message: string, statusCode = 400) {
+  constructor(message: string, statusCode = 400, metadata?: AppErrorMetadata) {
     super(message)
     this.statusCode = statusCode
+    this.metadata = metadata
   }
 }

--- a/backend/tests/site.service.spec.ts
+++ b/backend/tests/site.service.spec.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { siteCreate, siteFindFirst, siteFindMany, siteCount, siteUpdate, auditLogCreate, transaction } = vi.hoisted(() => ({
+  siteCreate: vi.fn(),
+  siteFindFirst: vi.fn(),
+  siteFindMany: vi.fn(),
+  siteCount: vi.fn(),
+  siteUpdate: vi.fn(),
+  auditLogCreate: vi.fn(),
+  transaction: vi.fn()
+}))
+
+vi.mock('../src/lib/prisma.js', () => ({
+  prisma: {
+    site: {
+      create: siteCreate,
+      findFirst: siteFindFirst,
+      findMany: siteFindMany,
+      count: siteCount,
+      update: siteUpdate
+    },
+    auditLog: {
+      create: auditLogCreate
+    },
+    $transaction: transaction
+  }
+}))
+
+import { SiteService } from '../src/services/master-data.service.js'
+
+describe('SiteService', () => {
+  const service = new SiteService()
+  const actor = { id: 'user-1', username: 'admin', role: 'admin' }
+  const meta = { ipAddress: '127.0.0.1', userAgent: 'vitest-agent' }
+  const site = {
+    id: 'site-1',
+    code: 'SITE-001',
+    nameZh: '中環地盤',
+    address: '中環',
+    startDate: new Date('2026-05-01T00:00:00.000Z'),
+    endDate: null,
+    pmName: null,
+    status: 'active',
+    remarks: null,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-01T00:00:00.000Z')
+  }
+
+  beforeEach(() => {
+    siteCreate.mockReset()
+    siteFindFirst.mockReset()
+    siteFindMany.mockReset()
+    siteCount.mockReset()
+    siteUpdate.mockReset()
+    auditLogCreate.mockReset()
+    transaction.mockReset()
+    transaction.mockImplementation(async (callback) =>
+      callback({ site: { create: siteCreate, update: siteUpdate }, auditLog: { create: auditLogCreate } })
+    )
+  })
+
+  it('creates a site and audit log in one transaction', async () => {
+    siteCreate.mockResolvedValue(site)
+    auditLogCreate.mockResolvedValue({})
+
+    const result = await service.create({ code: 'SITE-001', nameZh: '中環地盤', startDate: site.startDate }, actor, meta)
+
+    expect(result).toBe(site)
+    expect(transaction).toHaveBeenCalledOnce()
+    expect(siteCreate).toHaveBeenCalledWith({
+      data: { code: 'SITE-001', nameZh: '中環地盤', startDate: site.startDate, status: 'active' }
+    })
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'user-1',
+        username: 'admin',
+        action: 'create',
+        entity: 'site',
+        entityId: 'site-1',
+        oldValue: null,
+        newValue: JSON.stringify({
+          code: 'SITE-001',
+          nameZh: '中環地盤',
+          address: '中環',
+          startDate: '2026-05-01T00:00:00.000Z',
+          endDate: null,
+          pmName: null,
+          status: 'active',
+          remarks: null
+        }),
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest-agent'
+      })
+    })
+  })
+
+  it('does not write audit log when create fails', async () => {
+    siteCreate.mockRejectedValue(new Error('Unique constraint failed'))
+
+    await expect(service.create({ code: 'SITE-001', nameZh: '中環地盤', startDate: site.startDate }, actor, meta)).rejects.toThrow(
+      'Unique constraint failed'
+    )
+    expect(auditLogCreate).not.toHaveBeenCalled()
+  })
+
+  it('lists non-deleted sites by default', async () => {
+    siteFindMany.mockResolvedValue([site])
+    siteCount.mockResolvedValue(1)
+
+    const result = await service.list()
+
+    expect(result.meta).toEqual({ page: 1, limit: 50, total: 1 })
+    expect(siteFindMany).toHaveBeenCalledWith(expect.objectContaining({ where: { status: { not: 'deleted' } } }))
+    expect(siteCount).toHaveBeenCalledWith({ where: { status: { not: 'deleted' } } })
+  })
+
+  it('throws 404 when get misses or record is deleted', async () => {
+    siteFindFirst.mockResolvedValue(null)
+
+    await expect(service.get('site-1')).rejects.toMatchObject({ message: '地盤不存在', statusCode: 404 })
+    expect(siteFindFirst).toHaveBeenCalledWith({ where: { id: 'site-1', status: { not: 'deleted' } } })
+  })
+
+  it('updates a site and audits changed fields only', async () => {
+    const endDate = new Date('2026-06-01T00:00:00.000Z')
+    siteFindFirst.mockResolvedValue(site)
+    siteUpdate.mockResolvedValue({ ...site, endDate, status: 'closed' })
+    auditLogCreate.mockResolvedValue({})
+
+    await service.update('site-1', { endDate, status: 'closed' }, actor, meta)
+
+    expect(siteUpdate).toHaveBeenCalledWith({ where: { id: 'site-1' }, data: { endDate, status: 'closed' } })
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'update',
+        entity: 'site',
+        oldValue: JSON.stringify({ endDate: null, status: 'active' }),
+        newValue: JSON.stringify({ endDate: '2026-06-01T00:00:00.000Z', status: 'closed' })
+      })
+    })
+  })
+
+  it('writes update audit even when there is no field diff', async () => {
+    siteFindFirst.mockResolvedValue(site)
+    siteUpdate.mockResolvedValue(site)
+    auditLogCreate.mockResolvedValue({})
+
+    await service.update('site-1', { nameZh: '中環地盤' }, actor, meta)
+
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ oldValue: '{}', newValue: '{}' })
+    })
+  })
+
+  it('soft deletes by status and excludes deleted records from list/get', async () => {
+    siteFindFirst.mockResolvedValue(site)
+    siteUpdate.mockResolvedValue({ ...site, status: 'deleted' })
+    auditLogCreate.mockResolvedValue({})
+
+    await service.delete('site-1', actor, meta)
+
+    expect(siteUpdate).toHaveBeenCalledWith({ where: { id: 'site-1' }, data: { status: 'deleted' } })
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'delete',
+        entity: 'site',
+        oldValue: expect.stringContaining('SITE-001'),
+        newValue: JSON.stringify({ status: 'deleted' })
+      })
+    })
+  })
+})

--- a/backend/tests/subcontractor.service.spec.ts
+++ b/backend/tests/subcontractor.service.spec.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  subcontractorCreate,
+  subcontractorFindFirst,
+  subcontractorFindMany,
+  subcontractorCount,
+  subcontractorUpdate,
+  auditLogCreate,
+  transaction
+} = vi.hoisted(() => ({
+  subcontractorCreate: vi.fn(),
+  subcontractorFindFirst: vi.fn(),
+  subcontractorFindMany: vi.fn(),
+  subcontractorCount: vi.fn(),
+  subcontractorUpdate: vi.fn(),
+  auditLogCreate: vi.fn(),
+  transaction: vi.fn()
+}))
+
+vi.mock('../src/lib/prisma.js', () => ({
+  prisma: {
+    subcontractor: {
+      create: subcontractorCreate,
+      findFirst: subcontractorFindFirst,
+      findMany: subcontractorFindMany,
+      count: subcontractorCount,
+      update: subcontractorUpdate
+    },
+    auditLog: {
+      create: auditLogCreate
+    },
+    $transaction: transaction
+  }
+}))
+
+import { SubcontractorService } from '../src/services/master-data.service.js'
+
+describe('SubcontractorService', () => {
+  const service = new SubcontractorService()
+  const actor = { id: 'user-1', username: 'admin', role: 'admin' }
+  const meta = { ipAddress: '127.0.0.1', userAgent: 'vitest-agent' }
+  const subcontractor = {
+    id: 'sub-1',
+    code: 'SUB-A',
+    nameZh: '分判商 A',
+    nameEn: null,
+    brNo: null,
+    contactName: null,
+    contactPhone: null,
+    contactEmail: null,
+    status: 'active',
+    remarks: null,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-01T00:00:00.000Z')
+  }
+
+  beforeEach(() => {
+    subcontractorCreate.mockReset()
+    subcontractorFindFirst.mockReset()
+    subcontractorFindMany.mockReset()
+    subcontractorCount.mockReset()
+    subcontractorUpdate.mockReset()
+    auditLogCreate.mockReset()
+    transaction.mockReset()
+    transaction.mockImplementation(async (callback) =>
+      callback({ subcontractor: { create: subcontractorCreate, update: subcontractorUpdate }, auditLog: { create: auditLogCreate } })
+    )
+  })
+
+  it('creates a subcontractor and audit log in one transaction', async () => {
+    subcontractorCreate.mockResolvedValue(subcontractor)
+    auditLogCreate.mockResolvedValue({})
+
+    const result = await service.create({ code: 'SUB-A', nameZh: '分判商 A' }, actor, meta)
+
+    expect(result).toBe(subcontractor)
+    expect(transaction).toHaveBeenCalledOnce()
+    expect(subcontractorCreate).toHaveBeenCalledWith({ data: { code: 'SUB-A', nameZh: '分判商 A', status: 'active' } })
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'user-1',
+        username: 'admin',
+        action: 'create',
+        entity: 'subcontractor',
+        entityId: 'sub-1',
+        oldValue: null,
+        newValue: JSON.stringify({
+          code: 'SUB-A',
+          nameZh: '分判商 A',
+          nameEn: null,
+          brNo: null,
+          contactName: null,
+          contactPhone: null,
+          contactEmail: null,
+          status: 'active',
+          remarks: null
+        }),
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest-agent'
+      })
+    })
+  })
+
+  it('does not write audit log when create fails', async () => {
+    subcontractorCreate.mockRejectedValue(new Error('Unique constraint failed'))
+
+    await expect(service.create({ code: 'SUB-A', nameZh: '分判商 A' }, actor, meta)).rejects.toThrow('Unique constraint failed')
+    expect(auditLogCreate).not.toHaveBeenCalled()
+  })
+
+  it('lists non-deleted subcontractors by default', async () => {
+    subcontractorFindMany.mockResolvedValue([subcontractor])
+    subcontractorCount.mockResolvedValue(1)
+
+    const result = await service.list()
+
+    expect(result.meta).toEqual({ page: 1, limit: 50, total: 1 })
+    expect(subcontractorFindMany).toHaveBeenCalledWith(expect.objectContaining({ where: { status: { not: 'deleted' } } }))
+    expect(subcontractorCount).toHaveBeenCalledWith({ where: { status: { not: 'deleted' } } })
+  })
+
+  it('throws 404 when get misses or record is deleted', async () => {
+    subcontractorFindFirst.mockResolvedValue(null)
+
+    await expect(service.get('sub-1')).rejects.toMatchObject({ message: '分判商不存在', statusCode: 404 })
+    expect(subcontractorFindFirst).toHaveBeenCalledWith({ where: { id: 'sub-1', status: { not: 'deleted' } } })
+  })
+
+  it('updates a subcontractor and audits changed fields only', async () => {
+    subcontractorFindFirst.mockResolvedValue(subcontractor)
+    subcontractorUpdate.mockResolvedValue({ ...subcontractor, nameZh: '分判商 A2', status: 'inactive' })
+    auditLogCreate.mockResolvedValue({})
+
+    await service.update('sub-1', { nameZh: '分判商 A2', status: 'inactive' }, actor, meta)
+
+    expect(subcontractorUpdate).toHaveBeenCalledWith({ where: { id: 'sub-1' }, data: { nameZh: '分判商 A2', status: 'inactive' } })
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'update',
+        entity: 'subcontractor',
+        oldValue: JSON.stringify({ nameZh: '分判商 A', status: 'active' }),
+        newValue: JSON.stringify({ nameZh: '分判商 A2', status: 'inactive' })
+      })
+    })
+  })
+
+  it('writes update audit even when there is no field diff', async () => {
+    subcontractorFindFirst.mockResolvedValue(subcontractor)
+    subcontractorUpdate.mockResolvedValue(subcontractor)
+    auditLogCreate.mockResolvedValue({})
+
+    await service.update('sub-1', { nameZh: '分判商 A' }, actor, meta)
+
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ oldValue: '{}', newValue: '{}' })
+    })
+  })
+
+  it('soft deletes by status and excludes deleted records from list/get', async () => {
+    subcontractorFindFirst.mockResolvedValue(subcontractor)
+    subcontractorUpdate.mockResolvedValue({ ...subcontractor, status: 'deleted' })
+    auditLogCreate.mockResolvedValue({})
+
+    await service.delete('sub-1', actor, meta)
+
+    expect(subcontractorUpdate).toHaveBeenCalledWith({ where: { id: 'sub-1' }, data: { status: 'deleted' } })
+    expect(auditLogCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        action: 'delete',
+        entity: 'subcontractor',
+        oldValue: expect.stringContaining('SUB-A'),
+        newValue: JSON.stringify({ status: 'deleted' })
+      })
+    })
+  })
+})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,10 @@ import { Navigate, Route, Routes } from 'react-router'
 import { DashboardPage } from '@/pages/dashboard-page'
 import { ChangePasswordPage } from '@/pages/change-password-page'
 import { LoginPage } from '@/pages/login-page'
+import { SiteFormPage } from '@/pages/site-form-page'
+import { SitesListPage } from '@/pages/sites-list-page'
+import { SubcontractorFormPage } from '@/pages/subcontractor-form-page'
+import { SubcontractorsListPage } from '@/pages/subcontractors-list-page'
 import { ProtectedLayout } from '@/routes/protected-layout'
 
 function App() {
@@ -11,6 +15,12 @@ function App() {
       <Route element={<ProtectedLayout />}>
         <Route path="/change-password" element={<ChangePasswordPage />} />
         <Route path="/" element={<DashboardPage />} />
+        <Route path="/subcontractors" element={<SubcontractorsListPage />} />
+        <Route path="/subcontractors/new" element={<SubcontractorFormPage />} />
+        <Route path="/subcontractors/:id" element={<SubcontractorFormPage />} />
+        <Route path="/sites" element={<SitesListPage />} />
+        <Route path="/sites/new" element={<SiteFormPage />} />
+        <Route path="/sites/:id" element={<SiteFormPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/frontend/src/lib/master-data-api.ts
+++ b/frontend/src/lib/master-data-api.ts
@@ -1,0 +1,118 @@
+import { api } from '@/lib/api'
+
+export type PaginationMeta = {
+  page: number
+  limit: number
+  total: number
+}
+
+export type ListResponse<T> = {
+  success: true
+  data: T[]
+  meta: PaginationMeta
+}
+
+export type DetailResponse<T> = {
+  success: true
+  data: T
+}
+
+export type Subcontractor = {
+  id: string
+  code: string
+  nameZh: string
+  nameEn: string | null
+  brNo: string | null
+  contactName: string | null
+  contactPhone: string | null
+  contactEmail: string | null
+  status: 'active' | 'inactive' | 'deleted'
+  remarks: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type SubcontractorFormValues = {
+  code: string
+  nameZh: string
+  nameEn?: string
+  brNo?: string
+  contactName?: string
+  contactPhone?: string
+  contactEmail?: string
+  status?: 'active' | 'inactive'
+  remarks?: string
+}
+
+export type Site = {
+  id: string
+  code: string
+  nameZh: string
+  address: string | null
+  startDate: string
+  endDate: string | null
+  pmName: string | null
+  status: 'active' | 'closed' | 'deleted'
+  remarks: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type SiteFormValues = {
+  code: string
+  nameZh: string
+  address?: string
+  startDate: string
+  endDate?: string
+  pmName?: string
+  status?: 'active' | 'closed'
+  remarks?: string
+}
+
+export async function listSubcontractors(): Promise<ListResponse<Subcontractor>> {
+  const response = await api.get<ListResponse<Subcontractor>>('/subcontractors')
+  return response.data
+}
+
+export async function getSubcontractor(id: string): Promise<Subcontractor> {
+  const response = await api.get<DetailResponse<Subcontractor>>(`/subcontractors/${id}`)
+  return response.data.data
+}
+
+export async function createSubcontractor(values: SubcontractorFormValues): Promise<Subcontractor> {
+  const response = await api.post<DetailResponse<Subcontractor>>('/subcontractors', values)
+  return response.data.data
+}
+
+export async function updateSubcontractor(id: string, values: Omit<SubcontractorFormValues, 'code'>): Promise<Subcontractor> {
+  const response = await api.patch<DetailResponse<Subcontractor>>(`/subcontractors/${id}`, values)
+  return response.data.data
+}
+
+export async function deleteSubcontractor(id: string): Promise<void> {
+  await api.delete(`/subcontractors/${id}`)
+}
+
+export async function listSites(): Promise<ListResponse<Site>> {
+  const response = await api.get<ListResponse<Site>>('/sites')
+  return response.data
+}
+
+export async function getSite(id: string): Promise<Site> {
+  const response = await api.get<DetailResponse<Site>>(`/sites/${id}`)
+  return response.data.data
+}
+
+export async function createSite(values: SiteFormValues): Promise<Site> {
+  const response = await api.post<DetailResponse<Site>>('/sites', values)
+  return response.data.data
+}
+
+export async function updateSite(id: string, values: Omit<SiteFormValues, 'code'>): Promise<Site> {
+  const response = await api.patch<DetailResponse<Site>>(`/sites/${id}`, values)
+  return response.data.data
+}
+
+export async function deleteSite(id: string): Promise<void> {
+  await api.delete(`/sites/${id}`)
+}

--- a/frontend/src/pages/site-form-page.tsx
+++ b/frontend/src/pages/site-form-page.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import axios from 'axios'
+import { z } from 'zod'
+import { Button } from '@/components/ui/button'
+import { Field, FieldError, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { useToast } from '@/components/ui/toast'
+import { createSite, getSite, updateSite, type SiteFormValues } from '@/lib/master-data-api'
+
+const createSchema = z.object({
+  code: z.string().trim().min(1, '請輸入地盤代碼'),
+  nameZh: z.string().trim().min(1, '請輸入地盤名稱'),
+  address: z.string().optional(),
+  startDate: z.string().min(1, '請選擇開始日期'),
+  endDate: z.string().optional(),
+  pmName: z.string().optional(),
+  status: z.enum(['active', 'closed']),
+  remarks: z.string().optional()
+})
+
+const editSchema = createSchema.omit({ code: true })
+type CreateFormValues = z.infer<typeof createSchema>
+type EditFormValues = z.infer<typeof editSchema>
+type FormValues = CreateFormValues | EditFormValues
+
+function toDateInput(value: string | null): string {
+  return value ? value.slice(0, 10) : ''
+}
+
+function errorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    return error.response?.data?.error?.message ?? error.response?.data?.message ?? '儲存地盤失敗'
+  }
+  return '儲存地盤失敗'
+}
+
+export function SiteFormPage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const isEdit = Boolean(id)
+  const [serverError, setServerError] = useState('')
+  const { data, isLoading } = useQuery({
+    queryKey: ['site', id],
+    queryFn: () => getSite(id!),
+    enabled: isEdit
+  })
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting }
+  } = useForm<FormValues>({
+    resolver: zodResolver(isEdit ? editSchema : createSchema),
+    defaultValues: { status: 'active' }
+  })
+  const createMutation = useMutation({ mutationFn: createSite })
+  const updateMutation = useMutation({ mutationFn: (values: EditFormValues) => updateSite(id!, values) })
+
+  useEffect(() => {
+    if (data) {
+      reset({
+        nameZh: data.nameZh,
+        address: data.address ?? '',
+        startDate: toDateInput(data.startDate),
+        endDate: toDateInput(data.endDate),
+        pmName: data.pmName ?? '',
+        status: data.status === 'deleted' ? 'closed' : data.status,
+        remarks: data.remarks ?? ''
+      })
+    }
+  }, [data, reset])
+
+  const onSubmit = async (values: FormValues) => {
+    setServerError('')
+    try {
+      if (isEdit) {
+        await updateMutation.mutateAsync(values as EditFormValues)
+      } else {
+        await createMutation.mutateAsync(values as SiteFormValues)
+      }
+      toast.show(isEdit ? '已更新地盤' : '已新增地盤')
+      navigate('/sites')
+    } catch (error) {
+      setServerError(errorMessage(error))
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-6">
+      <section className="mx-auto max-w-2xl rounded-lg bg-white p-6 shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">{isEdit ? '編輯地盤' : '新增地盤'}</h1>
+        <p className="mt-1 text-sm text-slate-600">請輸入地盤基本資料。</p>
+        {isLoading ? <p className="mt-6 text-slate-600">載入中...</p> : null}
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit(onSubmit)}>
+          {!isEdit ? (
+            <Field>
+              <FieldLabel htmlFor="code">地盤代碼</FieldLabel>
+              <Input id="code" {...register('code')} />
+              <FieldError>{'code' in errors ? errors.code?.message : undefined}</FieldError>
+            </Field>
+          ) : null}
+          <Field>
+            <FieldLabel htmlFor="nameZh">地盤名稱</FieldLabel>
+            <Input id="nameZh" {...register('nameZh')} />
+            <FieldError>{errors.nameZh?.message}</FieldError>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="address">地址</FieldLabel>
+            <Input id="address" {...register('address')} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="startDate">開始日期</FieldLabel>
+            <Input id="startDate" type="date" {...register('startDate')} />
+            <FieldError>{errors.startDate?.message}</FieldError>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="endDate">結束日期</FieldLabel>
+            <Input id="endDate" type="date" {...register('endDate')} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="pmName">項目經理</FieldLabel>
+            <Input id="pmName" {...register('pmName')} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="status">狀態</FieldLabel>
+            <select className="h-10 w-full rounded-md border border-slate-300 px-3 text-sm" id="status" {...register('status')}>
+              <option value="active">啟用</option>
+              <option value="closed">已關閉</option>
+            </select>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="remarks">備註</FieldLabel>
+            <Input id="remarks" {...register('remarks')} />
+          </Field>
+          {serverError ? <p className="text-sm text-red-600">{serverError}</p> : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => navigate('/sites')}>
+              取消
+            </Button>
+            <Button disabled={isSubmitting || createMutation.isPending || updateMutation.isPending} type="submit">
+              {isSubmitting ? '儲存中...' : '儲存'}
+            </Button>
+          </div>
+        </form>
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/pages/sites-list-page.tsx
+++ b/frontend/src/pages/sites-list-page.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { useToast } from '@/components/ui/toast'
+import { deleteSite, listSites, type Site } from '@/lib/master-data-api'
+
+const statusLabels: Record<Site['status'], string> = {
+  active: '啟用',
+  closed: '已關閉',
+  deleted: '已刪除'
+}
+
+function formatDate(value: string | null): string {
+  return value ? value.slice(0, 10) : '-'
+}
+
+export function SitesListPage() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const toast = useToast()
+  const [target, setTarget] = useState<Site | null>(null)
+  const { data, isLoading, isError } = useQuery({ queryKey: ['sites'], queryFn: listSites })
+  const deleteMutation = useMutation({
+    mutationFn: deleteSite,
+    onSuccess: async () => {
+      setTarget(null)
+      await queryClient.invalidateQueries({ queryKey: ['sites'] })
+      toast.show('已刪除地盤')
+    }
+  })
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-6">
+      <section className="mx-auto max-w-6xl space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900">地盤</h1>
+            <p className="text-sm text-slate-600">管理地盤基本資料與狀態。</p>
+          </div>
+          <Button onClick={() => navigate('/sites/new')}>新增地盤</Button>
+        </div>
+
+        <div className="overflow-hidden rounded-lg bg-white shadow">
+          {isLoading ? <p className="p-6 text-slate-600">載入中...</p> : null}
+          {isError ? <p className="p-6 text-red-600">載入地盤失敗</p> : null}
+          {!isLoading && !isError && data?.data.length === 0 ? <p className="p-6 text-slate-600">尚未有地盤紀錄，請點「新增地盤」。</p> : null}
+          {data?.data.length ? (
+            <table className="w-full text-left text-sm">
+              <thead className="bg-slate-100 text-slate-700">
+                <tr>
+                  <th className="px-4 py-3">代碼</th>
+                  <th className="px-4 py-3">名稱</th>
+                  <th className="px-4 py-3">地址</th>
+                  <th className="px-4 py-3">開始日期</th>
+                  <th className="px-4 py-3">結束日期</th>
+                  <th className="px-4 py-3">項目經理</th>
+                  <th className="px-4 py-3">狀態</th>
+                  <th className="px-4 py-3">操作</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200">
+                {data.data.map((site) => (
+                  <tr key={site.id}>
+                    <td className="px-4 py-3 font-medium text-slate-900">{site.code}</td>
+                    <td className="px-4 py-3">{site.nameZh}</td>
+                    <td className="px-4 py-3">{site.address ?? '-'}</td>
+                    <td className="px-4 py-3">{formatDate(site.startDate)}</td>
+                    <td className="px-4 py-3">{formatDate(site.endDate)}</td>
+                    <td className="px-4 py-3">{site.pmName ?? '-'}</td>
+                    <td className="px-4 py-3">{statusLabels[site.status]}</td>
+                    <td className="space-x-2 px-4 py-3">
+                      <Link className="text-blue-600 hover:underline" to={`/sites/${site.id}`}>
+                        編輯
+                      </Link>
+                      <button className="text-red-600 hover:underline" type="button" onClick={() => setTarget(site)}>
+                        刪除
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : null}
+        </div>
+      </section>
+
+      <Dialog open={target !== null}>
+        <DialogContent>
+          <h2 className="text-lg font-semibold">確認刪除地盤</h2>
+          <p className="mt-2 text-sm text-slate-600">刪除後列表將不再顯示「{target?.nameZh}」。</p>
+          <div className="mt-6 flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setTarget(null)}>
+              取消
+            </Button>
+            <Button disabled={deleteMutation.isPending} onClick={() => target && deleteMutation.mutate(target.id)}>
+              {deleteMutation.isPending ? '刪除中...' : '確認刪除'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </main>
+  )
+}

--- a/frontend/src/pages/subcontractor-form-page.tsx
+++ b/frontend/src/pages/subcontractor-form-page.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import axios from 'axios'
+import { z } from 'zod'
+import { Button } from '@/components/ui/button'
+import { Field, FieldError, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { useToast } from '@/components/ui/toast'
+import {
+  createSubcontractor,
+  getSubcontractor,
+  updateSubcontractor,
+  type SubcontractorFormValues
+} from '@/lib/master-data-api'
+
+const createSchema = z.object({
+  code: z.string().trim().min(1, '請輸入分判商代碼'),
+  nameZh: z.string().trim().min(1, '請輸入分判商名稱'),
+  nameEn: z.string().optional(),
+  brNo: z.string().optional(),
+  contactName: z.string().optional(),
+  contactPhone: z.string().optional(),
+  contactEmail: z.string().email('電郵格式不正確').optional().or(z.literal('')),
+  status: z.enum(['active', 'inactive']),
+  remarks: z.string().optional()
+})
+
+const editSchema = createSchema.omit({ code: true })
+type CreateFormValues = z.infer<typeof createSchema>
+type EditFormValues = z.infer<typeof editSchema>
+type FormValues = CreateFormValues | EditFormValues
+
+function errorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    return error.response?.data?.error?.message ?? error.response?.data?.message ?? '儲存分判商失敗'
+  }
+  return '儲存分判商失敗'
+}
+
+export function SubcontractorFormPage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const isEdit = Boolean(id)
+  const [serverError, setServerError] = useState('')
+  const { data, isLoading } = useQuery({
+    queryKey: ['subcontractor', id],
+    queryFn: () => getSubcontractor(id!),
+    enabled: isEdit
+  })
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting }
+  } = useForm<FormValues>({
+    resolver: zodResolver(isEdit ? editSchema : createSchema),
+    defaultValues: { status: 'active' }
+  })
+  const createMutation = useMutation({ mutationFn: createSubcontractor })
+  const updateMutation = useMutation({ mutationFn: (values: EditFormValues) => updateSubcontractor(id!, values) })
+
+  useEffect(() => {
+    if (data) {
+      reset({
+        nameZh: data.nameZh,
+        nameEn: data.nameEn ?? '',
+        brNo: data.brNo ?? '',
+        contactName: data.contactName ?? '',
+        contactPhone: data.contactPhone ?? '',
+        contactEmail: data.contactEmail ?? '',
+        status: data.status === 'deleted' ? 'inactive' : data.status,
+        remarks: data.remarks ?? ''
+      })
+    }
+  }, [data, reset])
+
+  const onSubmit = async (values: FormValues) => {
+    setServerError('')
+    try {
+      if (isEdit) {
+        await updateMutation.mutateAsync(values as EditFormValues)
+      } else {
+        await createMutation.mutateAsync(values as SubcontractorFormValues)
+      }
+      toast.show(isEdit ? '已更新分判商' : '已新增分判商')
+      navigate('/subcontractors')
+    } catch (error) {
+      setServerError(errorMessage(error))
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-6">
+      <section className="mx-auto max-w-2xl rounded-lg bg-white p-6 shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">{isEdit ? '編輯分判商' : '新增分判商'}</h1>
+        <p className="mt-1 text-sm text-slate-600">請輸入分判商基本資料。</p>
+        {isLoading ? <p className="mt-6 text-slate-600">載入中...</p> : null}
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit(onSubmit)}>
+          {!isEdit ? (
+            <Field>
+              <FieldLabel htmlFor="code">分判商代碼</FieldLabel>
+              <Input id="code" {...register('code')} />
+              <FieldError>{'code' in errors ? errors.code?.message : undefined}</FieldError>
+            </Field>
+          ) : null}
+          <Field>
+            <FieldLabel htmlFor="nameZh">分判商名稱</FieldLabel>
+            <Input id="nameZh" {...register('nameZh')} />
+            <FieldError>{errors.nameZh?.message}</FieldError>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="nameEn">英文名稱</FieldLabel>
+            <Input id="nameEn" {...register('nameEn')} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="brNo">商業登記號碼</FieldLabel>
+            <Input id="brNo" {...register('brNo')} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="contactName">聯絡人</FieldLabel>
+            <Input id="contactName" {...register('contactName')} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="contactPhone">聯絡電話</FieldLabel>
+            <Input id="contactPhone" {...register('contactPhone')} />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="contactEmail">聯絡電郵</FieldLabel>
+            <Input id="contactEmail" {...register('contactEmail')} />
+            <FieldError>{errors.contactEmail?.message}</FieldError>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="status">狀態</FieldLabel>
+            <select className="h-10 w-full rounded-md border border-slate-300 px-3 text-sm" id="status" {...register('status')}>
+              <option value="active">啟用</option>
+              <option value="inactive">停用</option>
+            </select>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="remarks">備註</FieldLabel>
+            <Input id="remarks" {...register('remarks')} />
+          </Field>
+          {serverError ? <p className="text-sm text-red-600">{serverError}</p> : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => navigate('/subcontractors')}>
+              取消
+            </Button>
+            <Button disabled={isSubmitting || createMutation.isPending || updateMutation.isPending} type="submit">
+              {isSubmitting ? '儲存中...' : '儲存'}
+            </Button>
+          </div>
+        </form>
+      </section>
+    </main>
+  )
+}

--- a/frontend/src/pages/subcontractors-list-page.tsx
+++ b/frontend/src/pages/subcontractors-list-page.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { useToast } from '@/components/ui/toast'
+import { deleteSubcontractor, listSubcontractors, type Subcontractor } from '@/lib/master-data-api'
+
+const statusLabels: Record<Subcontractor['status'], string> = {
+  active: '啟用',
+  inactive: '停用',
+  deleted: '已刪除'
+}
+
+export function SubcontractorsListPage() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const toast = useToast()
+  const [target, setTarget] = useState<Subcontractor | null>(null)
+  const { data, isLoading, isError } = useQuery({ queryKey: ['subcontractors'], queryFn: listSubcontractors })
+  const deleteMutation = useMutation({
+    mutationFn: deleteSubcontractor,
+    onSuccess: async () => {
+      setTarget(null)
+      await queryClient.invalidateQueries({ queryKey: ['subcontractors'] })
+      toast.show('已刪除分判商')
+    }
+  })
+
+  return (
+    <main className="min-h-screen bg-slate-50 p-6">
+      <section className="mx-auto max-w-6xl space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900">分判商</h1>
+            <p className="text-sm text-slate-600">管理分判商基本資料與狀態。</p>
+          </div>
+          <Button onClick={() => navigate('/subcontractors/new')}>新增分判商</Button>
+        </div>
+
+        <div className="overflow-hidden rounded-lg bg-white shadow">
+          {isLoading ? <p className="p-6 text-slate-600">載入中...</p> : null}
+          {isError ? <p className="p-6 text-red-600">載入分判商失敗</p> : null}
+          {!isLoading && !isError && data?.data.length === 0 ? (
+            <p className="p-6 text-slate-600">尚未有分判商紀錄，請點「新增分判商」。</p>
+          ) : null}
+          {data?.data.length ? (
+            <table className="w-full text-left text-sm">
+              <thead className="bg-slate-100 text-slate-700">
+                <tr>
+                  <th className="px-4 py-3">代碼</th>
+                  <th className="px-4 py-3">名稱</th>
+                  <th className="px-4 py-3">BR</th>
+                  <th className="px-4 py-3">聯絡人</th>
+                  <th className="px-4 py-3">電話</th>
+                  <th className="px-4 py-3">狀態</th>
+                  <th className="px-4 py-3">操作</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200">
+                {data.data.map((subcontractor) => (
+                  <tr key={subcontractor.id}>
+                    <td className="px-4 py-3 font-medium text-slate-900">{subcontractor.code}</td>
+                    <td className="px-4 py-3">{subcontractor.nameZh}</td>
+                    <td className="px-4 py-3">{subcontractor.brNo ?? '-'}</td>
+                    <td className="px-4 py-3">{subcontractor.contactName ?? '-'}</td>
+                    <td className="px-4 py-3">{subcontractor.contactPhone ?? '-'}</td>
+                    <td className="px-4 py-3">{statusLabels[subcontractor.status]}</td>
+                    <td className="space-x-2 px-4 py-3">
+                      <Link className="text-blue-600 hover:underline" to={`/subcontractors/${subcontractor.id}`}>
+                        編輯
+                      </Link>
+                      <button className="text-red-600 hover:underline" type="button" onClick={() => setTarget(subcontractor)}>
+                        刪除
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : null}
+        </div>
+      </section>
+
+      <Dialog open={target !== null}>
+        <DialogContent>
+          <h2 className="text-lg font-semibold">確認刪除分判商</h2>
+          <p className="mt-2 text-sm text-slate-600">刪除後列表將不再顯示「{target?.nameZh}」。</p>
+          <div className="mt-6 flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setTarget(null)}>
+              取消
+            </Button>
+            <Button disabled={deleteMutation.isPending} onClick={() => target && deleteMutation.mutate(target.id)}>
+              {deleteMutation.isPending ? '刪除中...' : '確認刪除'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds Subcontractor and Site backend CRUD with PROJECT_SPEC §4.1 field names, status-based soft delete, and service-level audit transactions.
- Adds protected frontend list/create/edit routes for `/subcontractors` and `/sites`.
- Extends `validateBody` with opt-in v2 validation error shape while preserving Phase 1 legacy auth behavior.

## Issue #18 acceptance checklist
- [x] Subcontractor model service + controller + routes + Zod validation + tests
- [x] Site model service + controller + routes + Zod validation + tests
- [x] Frontend `/subcontractors` list + `/subcontractors/new` + `/subcontractors/:id` edit flow
- [x] Frontend `/sites` list + `/sites/new` + `/sites/:id` edit flow
- [x] Audit log writes follow PR #14/#17 service transaction pattern
- [x] Soft delete implemented with `status = 'deleted'`
- [x] Issue body `deletedAt` wording handled as not applicable: conflicts with PROJECT_SPEC §4.1, and CLAUDE.md says PROJECT_SPEC is source of truth
- [x] No `.env` / `.env.example` changes
- [x] No auth controller/service/page changes
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] Local API E2E flow for Subcontractor create → list → update → delete → list filtered
- [x] Local API E2E flow for Site create → list → update endDate → delete → list filtered

## Validation evidence
```txt
> attendance-system@1.0.0 build
> npm run build -w backend && npm run build -w frontend

> backend@1.0.0 build
> tsc -p tsconfig.json

> frontend@1.0.0 build
> tsc -b && vite build
✓ built in 3.27s

> attendance-system@1.0.0 test
> npm run test -w backend && npm run test -w frontend

backend: Test Files 4 passed (4), Tests 23 passed (23)
frontend: Test Files 3 passed (3), Tests 7 passed (7)

> attendance-system@1.0.0 lint
> npm run lint --workspaces --if-present

> backend@1.0.0 lint
> eslint "src/**/*.ts" "tests/**/*.ts"

> frontend@1.0.0 lint
> eslint .
```

## Local E2E API evidence
Subcontractor:
```txt
create: {"success":true,"data":{"code":"SUB-E2E","nameZh":"端對端分判商","status":"active"...}}
list after create: {"success":true,"data":[{"code":"SUB-E2E"...}],"meta":{"page":1,"limit":50,"total":1}}
update: {"success":true,"data":{"code":"SUB-E2E","status":"inactive"...}}
delete: {"success":true}
list after delete: {"success":true,"data":[],"meta":{"page":1,"limit":50,"total":0}}
```

Site:
```txt
create: {"success":true,"data":{"code":"SITE-E2E","nameZh":"端對端地盤","status":"active"...}}
list after create: {"success":true,"data":[{"code":"SITE-E2E"...}],"meta":{"page":1,"limit":50,"total":1}}
update endDate: {"success":true,"data":{"code":"SITE-E2E","endDate":"2026-06-01T00:00:00.000Z"...}}
delete: {"success":true}
list after delete: {"success":true,"data":[],"meta":{"page":1,"limit":50,"total":0}}
```

## Audit log SQL output
```txt
subcontractor|create|cmooma6d900084yd0egvd3s23||{"code":"SUB-E2E","nameZh":"端對端分判商","nameEn":null,"brNo":null,"contactName":null,"contactPhone":null,"contactEmail":null,"status":"active","remarks":null}|admin
subcontractor|update|cmooma6d900084yd0egvd3s23|{"status":"active"}|{"status":"inactive"}|admin
subcontractor|delete|cmooma6d900084yd0egvd3s23|{"code":"SUB-E2E","nameZh":"端對端分判商","nameEn":null,"brNo":null,"contactName":null,"contactPhone":null,"contactEmail":null,"status":"inactive","remarks":null}|{"status":"deleted"}|admin
site|create|cmoomald2000h4yd09oivisgy||{"code":"SITE-E2E","nameZh":"端對端地盤","address":"中環","startDate":"2026-05-01T00:00:00.000Z","endDate":null,"pmName":null,"status":"active","remarks":null}|admin
site|update|cmoomald2000h4yd09oivisgy|{"endDate":null}|{"endDate":"2026-06-01T00:00:00.000Z"}|admin
site|update|cmoomald2000h4yd09oivisgy|{}|{}|admin
site|delete|cmoomald2000h4yd09oivisgy|{"code":"SITE-E2E","nameZh":"端對端地盤","address":"中環","startDate":"2026-05-01T00:00:00.000Z","endDate":"2026-06-01T00:00:00.000Z","pmName":null,"status":"active","remarks":null}|{"status":"deleted"}|admin
SUB-E2E|deleted
SITE-E2E|deleted
```

## Follow-ups
1. RBAC: current endpoints only use `requireAuth`; create a separate issue for fine-grained RBAC so Subcontractor/Site mutations can be limited to admin/hr.
2. Validation response shape: codebase-wide unification should be a separate issue, including frontend auth pages handling the new error format.

Closes #18