### PR TITLE
test: add Phase 2a frontend page coverage

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/src/pages/site-form-page.test.tsx
+++ b/frontend/src/pages/site-form-page.test.tsx
@@ -1,0 +1,160 @@
+import { cleanup, screen, waitFor } from '@testing-library/react'
+import axios from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@/test/render-with-providers'
+import { SiteFormPage } from './site-form-page'
+import { createSite, getSite, updateSite, type Site } from '@/lib/master-data-api'
+
+const { navigateMock, toastShowMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  toastShowMock: vi.fn()
+}))
+
+let paramsMock: Record<string, string | undefined>
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => paramsMock
+  }
+})
+
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({ show: toastShowMock })
+}))
+
+vi.mock('@/lib/master-data-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/master-data-api')>('@/lib/master-data-api')
+  return {
+    ...actual,
+    createSite: vi.fn(),
+    getSite: vi.fn(),
+    updateSite: vi.fn()
+  }
+})
+
+const site: Site = {
+  id: 'site-1',
+  code: 'SITE-001',
+  nameZh: '中環地盤',
+  address: '中環',
+  startDate: '2026-05-01T00:00:00.000Z',
+  endDate: '2026-06-01T00:00:00.000Z',
+  pmName: '李經理',
+  status: 'active',
+  remarks: '備註',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z'
+}
+
+describe('SiteFormPage', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    paramsMock = {}
+    navigateMock.mockReset()
+    toastShowMock.mockReset()
+    vi.mocked(createSite).mockReset()
+    vi.mocked(getSite).mockReset()
+    vi.mocked(updateSite).mockReset()
+    vi.spyOn(axios, 'isAxiosError').mockReturnValue(false)
+  })
+
+  it('renders create mode fields', () => {
+    renderWithProviders(<SiteFormPage />, { route: '/sites/new' })
+
+    expect(screen.getByRole('heading', { name: '新增地盤' })).toBeInTheDocument()
+    expect(screen.getByLabelText('地盤代碼')).toBeInTheDocument()
+    expect(screen.getByLabelText('地盤名稱')).toBeInTheDocument()
+    expect(screen.getByLabelText('開始日期')).toBeInTheDocument()
+  })
+
+  it('blocks create submit when required fields are empty', async () => {
+    const { user } = renderWithProviders(<SiteFormPage />, { route: '/sites/new' })
+
+    await user.click(screen.getByRole('button', { name: '儲存' }))
+
+    expect(await screen.findByText('請輸入地盤代碼')).toBeInTheDocument()
+    expect(screen.getByText('請輸入地盤名稱')).toBeInTheDocument()
+    expect(screen.getByText('請選擇開始日期')).toBeInTheDocument()
+    expect(createSite).not.toHaveBeenCalled()
+  })
+
+  it('creates site and navigates back to list', async () => {
+    vi.mocked(createSite).mockResolvedValue(site)
+    const { user } = renderWithProviders(<SiteFormPage />, { route: '/sites/new' })
+
+    await user.type(screen.getByLabelText('地盤代碼'), 'SITE-001')
+    await user.type(screen.getByLabelText('地盤名稱'), '中環地盤')
+    await user.type(screen.getByLabelText('開始日期'), '2026-05-01')
+    await user.click(screen.getByRole('button', { name: '儲存' }))
+
+    await waitFor(() => {
+      expect(createSite).toHaveBeenCalled()
+    })
+    expect(vi.mocked(createSite).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ code: 'SITE-001', nameZh: '中環地盤', startDate: '2026-05-01', status: 'active' })
+    )
+    expect(toastShowMock).toHaveBeenCalledWith(expect.stringMatching(/已新增|已更新|成功/))
+    expect(navigateMock).toHaveBeenCalledWith('/sites')
+  })
+
+  it('loads edit mode data, formats dates, and hides immutable code field', async () => {
+    paramsMock = { id: 'site-1' }
+    vi.mocked(getSite).mockResolvedValue(site)
+
+    renderWithProviders(<SiteFormPage />, { route: '/sites/site-1' })
+
+    expect(await screen.findByDisplayValue('中環地盤')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('中環')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('2026-05-01')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('2026-06-01')).toBeInTheDocument()
+    expect(screen.queryByLabelText('地盤代碼')).not.toBeInTheDocument()
+  })
+
+  it('updates site without sending code', async () => {
+    paramsMock = { id: 'site-1' }
+    vi.mocked(getSite).mockResolvedValue(site)
+    vi.mocked(updateSite).mockResolvedValue({ ...site, endDate: '2026-07-01T00:00:00.000Z', status: 'closed' })
+    const { user } = renderWithProviders(<SiteFormPage />, { route: '/sites/site-1' })
+
+    const endDateInput = await screen.findByLabelText('結束日期')
+    await waitFor(() => {
+      expect(endDateInput).toHaveValue('2026-06-01')
+    })
+    await user.clear(endDateInput)
+    await user.type(endDateInput, '2026-07-01')
+    await user.selectOptions(screen.getByLabelText('狀態'), 'closed')
+    await user.click(screen.getByRole('button', { name: '儲存' }))
+
+    await waitFor(() => {
+      expect(updateSite).toHaveBeenCalled()
+    })
+    expect(vi.mocked(updateSite).mock.calls[0]?.[0]).toBe('site-1')
+    expect(vi.mocked(updateSite).mock.calls[0]?.[1]).not.toEqual(expect.objectContaining({ code: expect.anything() }))
+    expect(vi.mocked(updateSite).mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ endDate: '2026-07-01', status: 'closed' })
+    )
+    expect(toastShowMock).toHaveBeenCalledWith(expect.stringMatching(/已新增|已更新|成功/))
+    expect(navigateMock).toHaveBeenCalledWith('/sites')
+  })
+
+  it('shows backend validation error message', async () => {
+    vi.mocked(axios.isAxiosError).mockReturnValue(true)
+    vi.mocked(createSite).mockRejectedValue({ response: { data: { error: { message: '驗證錯誤' } } } })
+    const { user } = renderWithProviders(<SiteFormPage />, { route: '/sites/new' })
+
+    await user.type(screen.getByLabelText('地盤代碼'), 'SITE-001')
+    await user.type(screen.getByLabelText('地盤名稱'), '中環地盤')
+    await user.type(screen.getByLabelText('開始日期'), '2026-05-01')
+    await user.click(screen.getByRole('button', { name: '儲存' }))
+
+    expect(await screen.findByText('驗證錯誤')).toBeInTheDocument()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/sites-list-page.test.tsx
+++ b/frontend/src/pages/sites-list-page.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@/test/render-with-providers'
+import { SitesListPage } from './sites-list-page'
+import { deleteSite, listSites, type ListResponse, type Site } from '@/lib/master-data-api'
+
+const { navigateMock, toastShowMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  toastShowMock: vi.fn()
+}))
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock
+  }
+})
+
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({ show: toastShowMock })
+}))
+
+vi.mock('@/lib/master-data-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/master-data-api')>('@/lib/master-data-api')
+  return {
+    ...actual,
+    listSites: vi.fn(),
+    deleteSite: vi.fn()
+  }
+})
+
+const site: Site = {
+  id: 'site-1',
+  code: 'SITE-001',
+  nameZh: '中環地盤',
+  address: '中環',
+  startDate: '2026-05-01T00:00:00.000Z',
+  endDate: '2026-06-01T00:00:00.000Z',
+  pmName: '李經理',
+  status: 'closed',
+  remarks: null,
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z'
+}
+
+function listResponse(data: Site[]): ListResponse<Site> {
+  return { success: true, data, meta: { page: 1, limit: 50, total: data.length } }
+}
+
+describe('SitesListPage', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    navigateMock.mockReset()
+    toastShowMock.mockReset()
+    vi.mocked(listSites).mockReset()
+    vi.mocked(deleteSite).mockReset()
+  })
+
+  it('shows loading state while sites are loading', () => {
+    vi.mocked(listSites).mockReturnValue(new Promise(() => {}))
+
+    renderWithProviders(<SitesListPage />)
+
+    expect(screen.getByText('載入中...')).toBeInTheDocument()
+  })
+
+  it('shows empty state when there are no sites', async () => {
+    vi.mocked(listSites).mockResolvedValue(listResponse([]))
+
+    renderWithProviders(<SitesListPage />)
+
+    expect(await screen.findByText('尚未有地盤紀錄，請點「新增地盤」。')).toBeInTheDocument()
+  })
+
+  it('renders site table rows', async () => {
+    vi.mocked(listSites).mockResolvedValue(listResponse([site]))
+
+    renderWithProviders(<SitesListPage />)
+
+    const row = await screen.findByRole('row', { name: /SITE-001/ })
+    expect(within(row).getByText('中環地盤')).toBeInTheDocument()
+    expect(within(row).getByText('中環')).toBeInTheDocument()
+    expect(within(row).getByText('2026-05-01')).toBeInTheDocument()
+    expect(within(row).getByText('2026-06-01')).toBeInTheDocument()
+    expect(within(row).getByText('李經理')).toBeInTheDocument()
+    expect(within(row).getByText('已關閉')).toBeInTheDocument()
+  })
+
+  it('navigates to create page when clicking add button', async () => {
+    vi.mocked(listSites).mockResolvedValue(listResponse([]))
+    const { user } = renderWithProviders(<SitesListPage />)
+
+    await user.click(screen.getByRole('button', { name: '新增地盤' }))
+
+    expect(navigateMock).toHaveBeenCalledWith('/sites/new')
+  })
+
+  it('navigates to edit page when clicking edit link', async () => {
+    vi.mocked(listSites).mockResolvedValue(listResponse([site]))
+    renderWithProviders(<SitesListPage />)
+
+    const editLink = await screen.findByRole('link', { name: '編輯' })
+
+    expect(editLink).toHaveAttribute('href', '/sites/site-1')
+  })
+
+  it('deletes after confirmation and invalidates the list query', async () => {
+    vi.mocked(listSites).mockResolvedValue(listResponse([site]))
+    vi.mocked(deleteSite).mockResolvedValue(undefined)
+    const { user, queryClient } = renderWithProviders(<SitesListPage />)
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const row = await screen.findByRole('row', { name: /SITE-001/ })
+    await user.click(within(row).getByRole('button', { name: '刪除' }))
+    expect(screen.getByText('確認刪除地盤')).toBeInTheDocument()
+    expect(screen.getAllByText(/中環地盤/).length).toBeGreaterThan(1)
+
+    await user.click(screen.getByRole('button', { name: '確認刪除' }))
+
+    await waitFor(() => {
+      expect(deleteSite).toHaveBeenCalled()
+    })
+    expect(vi.mocked(deleteSite).mock.calls[0]?.[0]).toBe('site-1')
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['sites'] })
+    expect(toastShowMock).toHaveBeenCalledWith(expect.stringMatching(/刪除/))
+  })
+})

--- a/frontend/src/pages/subcontractor-form-page.test.tsx
+++ b/frontend/src/pages/subcontractor-form-page.test.tsx
@@ -1,0 +1,161 @@
+import { cleanup, screen, waitFor } from '@testing-library/react'
+import axios from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@/test/render-with-providers'
+import { SubcontractorFormPage } from './subcontractor-form-page'
+import {
+  createSubcontractor,
+  getSubcontractor,
+  updateSubcontractor,
+  type Subcontractor
+} from '@/lib/master-data-api'
+
+const { navigateMock, toastShowMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  toastShowMock: vi.fn()
+}))
+
+let paramsMock: Record<string, string | undefined>
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => paramsMock
+  }
+})
+
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({ show: toastShowMock })
+}))
+
+vi.mock('@/lib/master-data-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/master-data-api')>('@/lib/master-data-api')
+  return {
+    ...actual,
+    createSubcontractor: vi.fn(),
+    getSubcontractor: vi.fn(),
+    updateSubcontractor: vi.fn()
+  }
+})
+
+const subcontractor: Subcontractor = {
+  id: 'sub-1',
+  code: 'SUB-A',
+  nameZh: '分判商 A',
+  nameEn: 'Sub A',
+  brNo: '12345678',
+  contactName: '陳生',
+  contactPhone: '91234567',
+  contactEmail: 'sub@example.com',
+  status: 'active',
+  remarks: '備註',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z'
+}
+
+describe('SubcontractorFormPage', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    paramsMock = {}
+    navigateMock.mockReset()
+    toastShowMock.mockReset()
+    vi.mocked(createSubcontractor).mockReset()
+    vi.mocked(getSubcontractor).mockReset()
+    vi.mocked(updateSubcontractor).mockReset()
+    vi.spyOn(axios, 'isAxiosError').mockReturnValue(false)
+  })
+
+  it('renders create mode fields', () => {
+    renderWithProviders(<SubcontractorFormPage />, { route: '/subcontractors/new' })
+
+    expect(screen.getByRole('heading', { name: '新增分判商' })).toBeInTheDocument()
+    expect(screen.getByLabelText('分判商代碼')).toBeInTheDocument()
+    expect(screen.getByLabelText('分判商名稱')).toBeInTheDocument()
+  })
+
+  it('blocks create submit when required fields are empty', async () => {
+    const { user } = renderWithProviders(<SubcontractorFormPage />, { route: '/subcontractors/new' })
+
+    await user.click(screen.getByRole('button', { name: '儲存' }))
+
+    expect(await screen.findByText('請輸入分判商代碼')).toBeInTheDocument()
+    expect(screen.getByText('請輸入分判商名稱')).toBeInTheDocument()
+    expect(createSubcontractor).not.toHaveBeenCalled()
+  })
+
+  it('creates subcontractor and navigates back to list', async () => {
+    vi.mocked(createSubcontractor).mockResolvedValue(subcontractor)
+    const { user } = renderWithProviders(<SubcontractorFormPage />, { route: '/subcontractors/new' })
+
+    await user.type(screen.getByLabelText('分判商代碼'), 'SUB-A')
+    await user.type(screen.getByLabelText('分判商名稱'), '分判商 A')
+    await user.click(screen.getByRole('button', { name: '儲存' }))
+
+    await waitFor(() => {
+      expect(createSubcontractor).toHaveBeenCalled()
+    })
+    expect(vi.mocked(createSubcontractor).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ code: 'SUB-A', nameZh: '分判商 A', status: 'active' })
+    )
+    expect(toastShowMock).toHaveBeenCalledWith(expect.stringMatching(/已新增|已更新|成功/))
+    expect(navigateMock).toHaveBeenCalledWith('/subcontractors')
+  })
+
+  it('loads edit mode data and hides immutable code field', async () => {
+    paramsMock = { id: 'sub-1' }
+    vi.mocked(getSubcontractor).mockResolvedValue(subcontractor)
+
+    renderWithProviders(<SubcontractorFormPage />, { route: '/subcontractors/sub-1' })
+
+    expect(await screen.findByDisplayValue('分判商 A')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Sub A')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('12345678')).toBeInTheDocument()
+    expect(screen.queryByLabelText('分判商代碼')).not.toBeInTheDocument()
+  })
+
+  it('updates subcontractor without sending code', async () => {
+    paramsMock = { id: 'sub-1' }
+    vi.mocked(getSubcontractor).mockResolvedValue(subcontractor)
+    vi.mocked(updateSubcontractor).mockResolvedValue({ ...subcontractor, nameZh: '分判商 B', status: 'inactive' })
+    const { user } = renderWithProviders(<SubcontractorFormPage />, { route: '/subcontractors/sub-1' })
+
+    const nameInput = await screen.findByLabelText('分判商名稱')
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('分判商 A')
+    })
+    await user.clear(nameInput)
+    await user.type(nameInput, '分判商 B')
+    await user.selectOptions(screen.getByLabelText('狀態'), 'inactive')
+    await user.click(screen.getByRole('button', { name: '儲存' }))
+
+    await waitFor(() => {
+      expect(updateSubcontractor).toHaveBeenCalled()
+    })
+    expect(vi.mocked(updateSubcontractor).mock.calls[0]?.[0]).toBe('sub-1')
+    expect(vi.mocked(updateSubcontractor).mock.calls[0]?.[1]).not.toEqual(expect.objectContaining({ code: expect.anything() }))
+    expect(vi.mocked(updateSubcontractor).mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ nameZh: '分判商 B', status: 'inactive' })
+    )
+    expect(toastShowMock).toHaveBeenCalledWith(expect.stringMatching(/已新增|已更新|成功/))
+    expect(navigateMock).toHaveBeenCalledWith('/subcontractors')
+  })
+
+  it('shows backend validation error message', async () => {
+    vi.mocked(axios.isAxiosError).mockReturnValue(true)
+    vi.mocked(createSubcontractor).mockRejectedValue({ response: { data: { error: { message: '驗證錯誤' } } } })
+    const { user } = renderWithProviders(<SubcontractorFormPage />, { route: '/subcontractors/new' })
+
+    await user.type(screen.getByLabelText('分判商代碼'), 'SUB-A')
+    await user.type(screen.getByLabelText('分判商名稱'), '分判商 A')
+    await user.click(screen.getByRole('button', { name: '儲存' }))
+
+    expect(await screen.findByText('驗證錯誤')).toBeInTheDocument()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/subcontractors-list-page.test.tsx
+++ b/frontend/src/pages/subcontractors-list-page.test.tsx
@@ -1,0 +1,137 @@
+import { cleanup, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@/test/render-with-providers'
+import { SubcontractorsListPage } from './subcontractors-list-page'
+import {
+  deleteSubcontractor,
+  listSubcontractors,
+  type ListResponse,
+  type Subcontractor
+} from '@/lib/master-data-api'
+
+const { navigateMock, toastShowMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  toastShowMock: vi.fn()
+}))
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock
+  }
+})
+
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({ show: toastShowMock })
+}))
+
+vi.mock('@/lib/master-data-api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/master-data-api')>('@/lib/master-data-api')
+  return {
+    ...actual,
+    listSubcontractors: vi.fn(),
+    deleteSubcontractor: vi.fn()
+  }
+})
+
+const subcontractor: Subcontractor = {
+  id: 'sub-1',
+  code: 'SUB-A',
+  nameZh: '分判商 A',
+  nameEn: null,
+  brNo: '12345678',
+  contactName: '陳生',
+  contactPhone: '91234567',
+  contactEmail: null,
+  status: 'active',
+  remarks: null,
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z'
+}
+
+function listResponse(data: Subcontractor[]): ListResponse<Subcontractor> {
+  return { success: true, data, meta: { page: 1, limit: 50, total: data.length } }
+}
+
+describe('SubcontractorsListPage', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  beforeEach(() => {
+    navigateMock.mockReset()
+    toastShowMock.mockReset()
+    vi.mocked(listSubcontractors).mockReset()
+    vi.mocked(deleteSubcontractor).mockReset()
+  })
+
+  it('shows loading state while subcontractors are loading', () => {
+    vi.mocked(listSubcontractors).mockReturnValue(new Promise(() => {}))
+
+    renderWithProviders(<SubcontractorsListPage />)
+
+    expect(screen.getByText('載入中...')).toBeInTheDocument()
+  })
+
+  it('shows empty state when there are no subcontractors', async () => {
+    vi.mocked(listSubcontractors).mockResolvedValue(listResponse([]))
+
+    renderWithProviders(<SubcontractorsListPage />)
+
+    expect(await screen.findByText('尚未有分判商紀錄，請點「新增分判商」。')).toBeInTheDocument()
+  })
+
+  it('renders subcontractor table rows', async () => {
+    vi.mocked(listSubcontractors).mockResolvedValue(listResponse([subcontractor]))
+
+    renderWithProviders(<SubcontractorsListPage />)
+
+    const row = await screen.findByRole('row', { name: /SUB-A/ })
+    expect(within(row).getByText('分判商 A')).toBeInTheDocument()
+    expect(within(row).getByText('12345678')).toBeInTheDocument()
+    expect(within(row).getByText('陳生')).toBeInTheDocument()
+    expect(within(row).getByText('91234567')).toBeInTheDocument()
+    expect(within(row).getByText('啟用')).toBeInTheDocument()
+  })
+
+  it('navigates to create page when clicking add button', async () => {
+    vi.mocked(listSubcontractors).mockResolvedValue(listResponse([]))
+    const { user } = renderWithProviders(<SubcontractorsListPage />)
+
+    await user.click(screen.getByRole('button', { name: '新增分判商' }))
+
+    expect(navigateMock).toHaveBeenCalledWith('/subcontractors/new')
+  })
+
+  it('navigates to edit page when clicking edit link', async () => {
+    vi.mocked(listSubcontractors).mockResolvedValue(listResponse([subcontractor]))
+    renderWithProviders(<SubcontractorsListPage />)
+
+    const editLink = await screen.findByRole('link', { name: '編輯' })
+
+    expect(editLink).toHaveAttribute('href', '/subcontractors/sub-1')
+  })
+
+  it('deletes after confirmation and invalidates the list query', async () => {
+    vi.mocked(listSubcontractors).mockResolvedValue(listResponse([subcontractor]))
+    vi.mocked(deleteSubcontractor).mockResolvedValue(undefined)
+    const { user, queryClient } = renderWithProviders(<SubcontractorsListPage />)
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const row = await screen.findByRole('row', { name: /SUB-A/ })
+    await user.click(within(row).getByRole('button', { name: '刪除' }))
+    expect(screen.getByText('確認刪除分判商')).toBeInTheDocument()
+    expect(screen.getAllByText(/分判商 A/).length).toBeGreaterThan(1)
+
+    await user.click(screen.getByRole('button', { name: '確認刪除' }))
+
+    await waitFor(() => {
+      expect(deleteSubcontractor).toHaveBeenCalled()
+    })
+    expect(vi.mocked(deleteSubcontractor).mock.calls[0]?.[0]).toBe('sub-1')
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['subcontractors'] })
+    expect(toastShowMock).toHaveBeenCalledWith(expect.stringMatching(/刪除/))
+  })
+})

--- a/frontend/src/test/render-with-providers.tsx
+++ b/frontend/src/test/render-with-providers.tsx
@@ -1,0 +1,34 @@
+import { type ReactElement } from 'react'
+import { render, type RenderResult } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router'
+
+type RenderWithProvidersOptions = {
+  route?: string
+}
+
+type RenderWithProvidersResult = RenderResult & {
+  queryClient: QueryClient
+  user: ReturnType<typeof userEvent.setup>
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  options: RenderWithProvidersOptions = {}
+): RenderWithProvidersResult {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
+  const user = userEvent.setup()
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[options.route ?? '/']}>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  )
+
+  return { ...result, queryClient, user }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -466,6 +466,7 @@
         "@tailwindcss/vite": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -3592,6 +3593,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {


### PR DESCRIPTION
## Summary
- Adds RTL/Vitest coverage for the four Phase 2a Subcontractor/Site pages.
- Adds a test-only `renderWithProviders` helper with QueryClientProvider + MemoryRouter.
- Adds `@testing-library/user-event` for behavior-focused interactions in the new tests.

## Issue #20 acceptance coverage

### `subcontractors-list-page.test.tsx`
- [x] loading state
- [x] empty state
- [x] table row render
- [x] navigate to create page
- [x] navigate to edit page via row edit link
- [x] delete confirm flow calls API, invalidates query, and shows delete toast

### `subcontractor-form-page.test.tsx`
- [x] create mode renders fields
- [x] create validation blocks submit
- [x] create submit calls API and navigates to list
- [x] edit mode loads data and hides immutable code field
- [x] edit submit calls update without code
- [x] backend validation error message is displayed

### `sites-list-page.test.tsx`
- [x] loading state
- [x] empty state
- [x] table row render
- [x] navigate to create page
- [x] navigate to edit page via row edit link
- [x] delete confirm flow calls API, invalidates query, and shows delete toast

### `site-form-page.test.tsx`
- [x] create mode renders fields
- [x] create validation blocks submit
- [x] create submit calls API and navigates to list
- [x] edit mode loads data, formats dates, and hides immutable code field
- [x] edit submit calls update without code
- [x] backend validation error message is displayed

## Test count
- Before: frontend tests `7`
- After: frontend tests `31`
- Added: `24` frontend tests across 4 new spec files

## Validation evidence
```txt
> attendance-system@1.0.0 test
> npm run test -w backend && npm run test -w frontend

backend: Test Files 4 passed (4), Tests 23 passed (23)
frontend: Test Files 7 passed (7), Tests 31 passed (31)
```

```txt
> npm run build -w backend && npm run build -w frontend
> tsc -p tsconfig.json
> tsc -b && vite build
✓ built in 2.01s
```

```txt
> attendance-system@1.0.0 lint
> npm run lint --workspaces --if-present

> backend@1.0.0 lint
> eslint "src/**/*.ts" "tests/**/*.ts"

> frontend@1.0.0 lint
> eslint .
```

## Notes
- Existing `change-password-page.test.tsx` continues using `fireEvent`; new tests use `user-event` v14 for user-focused interactions.
- Follow-up: standardize all frontend tests on `user-event` where practical.

Closes #20